### PR TITLE
Patched namespace and extern C issue.

### DIFF
--- a/compiler-rt/lib/mpk_untrusted/alloc_site_handler.cpp
+++ b/compiler-rt/lib/mpk_untrusted/alloc_site_handler.cpp
@@ -4,9 +4,12 @@ namespace __mpk_untrusted {
 
 std::shared_ptr<AllocSiteHandler> AllocSiteHandler::handle = nullptr;
 
+} // namespace __mpk_untrusted
+
+extern "C" {
 void allocHook(rust_ptr ptr, int64_t size, int64_t uniqueID) {
-  AllocSite site(ptr, size, uniqueID);
-  auto handler = AllocSiteHandler::init();
+  __mpk_untrusted::AllocSite site(ptr, size, uniqueID);
+  auto handler = __mpk_untrusted::AllocSiteHandler::init();
   handler->insertAllocSite(ptr, site);
   __sanitizer::Report("INFO : AllocSiteHook for address: %p ID: %d.\n", ptr,
                       uniqueID);
@@ -18,9 +21,9 @@ void reallocHook(rust_ptr newPtr, int64_t newSize, rust_ptr oldPtr,
                  int64_t oldSize, int64_t uniqueID) {
   // TODO : For now we are simply going to remove the old one and input the new
   // one.
-  auto handler = AllocSiteHandler::init();
+  auto handler = __mpk_untrusted::AllocSiteHandler::init();
   handler->removeAllocSite(oldPtr);
-  AllocSite site(newPtr, newSize, uniqueID);
+  __mpk_untrusted::AllocSite site(newPtr, newSize, uniqueID);
   handler->insertAllocSite(newPtr, site);
   __sanitizer::Report(
       "INFO : ReallocSiteHook for oldptr: %p, newptr: %p, ID: %d.\n", oldPtr,
@@ -28,10 +31,10 @@ void reallocHook(rust_ptr newPtr, int64_t newSize, rust_ptr oldPtr,
 }
 
 void deallocHook(rust_ptr ptr, int64_t size, int64_t uniqueID) {
-  auto handler = AllocSiteHandler::init();
+  auto handler = __mpk_untrusted::AllocSiteHandler::init();
   handler->removeAllocSite(ptr);
   __sanitizer::Report("INFO : DeallocSiteHook for address: %p ID: %d.\n", ptr,
                       uniqueID);
 }
+}
 
-} // namespace __mpk_untrusted


### PR DESCRIPTION
Removed the hook function definitions from the `__mpk_untrusted` namespace and moved them into an `extern "C"` to ensure the names are not mangled.