### PR TITLE
Currently working commit of the Dynamic Analysis approach:

### DIFF
--- a/compiler-rt/lib/mpk_untrusted/alloc_site_handler.cpp
+++ b/compiler-rt/lib/mpk_untrusted/alloc_site_handler.cpp
@@ -1,6 +1,12 @@
 #include "alloc_site_handler.h"
 
+extern "C" {
+  bool is_safe_address(void* addr) { return false; }
+}
+
 namespace __mpk_untrusted {
+#define DEFAULT_PKEY 0
+#define IS_REALLOC 1
 
 AllocSiteHandler* AllocSiteHandle = nullptr;
 
@@ -29,7 +35,7 @@ void allocHook(rust_ptr ptr, int64_t size, int64_t localID, const char *bbName, 
   __mpk_untrusted::AllocSite site(ptr, size, localID, bbName, funcName);
   auto handler = __mpk_untrusted::AllocSiteHandler::getOrInit();
   handler->insertAllocSite(ptr, site);
-  REPORT("INFO : AllocSiteHook for address: %p ID: %d.\n", ptr, localID);
+  REPORT("INFO : AllocSiteHook for address: %p ID: %d bbName: %s funcName: %s.\n", ptr, localID, bbName, funcName);
 
 #ifdef MPK_STATS
   if (AllocSiteCount != 0)
@@ -67,10 +73,10 @@ void reallocHook(rust_ptr newPtr, int64_t newSize, rust_ptr oldPtr,
   // Create new Allocation Site for given pointer, adding the previous
   // Allocation Site and its associated set to the new AllocSite's associated
   // set.
-  __mpk_untrusted::AllocSite site(newPtr, newSize, localID, bbName, funcName, 0, 1, assocSet);
+  __mpk_untrusted::AllocSite site(newPtr, newSize, localID, bbName, funcName, DEFAULT_PKEY, IS_REALLOC, assocSet);
   handler->insertAllocSite(newPtr, site);
-  REPORT("INFO : ReallocSiteHook for oldptr: %p, newptr: %p, ID: %d.\n",
-         oldPtr, newPtr, localID);
+  REPORT("INFO : ReallocSiteHook for oldptr: %p, newptr: %p, ID: %d bbName: %s funcName: %s.\n",
+         oldPtr, newPtr, localID, bbName, funcName);
 
 #ifdef MPK_STATS
   if (AllocSiteCount != 0)

--- a/compiler-rt/lib/mpk_untrusted/alloc_site_handler.cpp
+++ b/compiler-rt/lib/mpk_untrusted/alloc_site_handler.cpp
@@ -57,7 +57,7 @@ void reallocHook(rust_ptr newPtr, int64_t newSize, rust_ptr oldPtr,
     // Returned ErrorAlloc, which should not be part of the realloc chain.
     __mpk_untrusted::AllocSite site(newPtr, newSize, localID, bbName, funcName);
     handler->insertAllocSite(newPtr, site);
-    REPORT("ERROR<AllocSite> : Realloc Site: %p : %d could not find the associated previous allocation: %d\n",
+    REPORT("ERROR<AllocSite> : Realloc Site: %p : %d could not find the previous allocation: %d\n",
             newPtr, site.id(), assocSite.id());
     return;
   }

--- a/compiler-rt/lib/mpk_untrusted/alloc_site_handler.cpp
+++ b/compiler-rt/lib/mpk_untrusted/alloc_site_handler.cpp
@@ -25,11 +25,11 @@ AllocSiteHandler* AllocSiteHandler::getOrInit() {
 } // namespace __mpk_untrusted
 
 extern "C" {
-void allocHook(rust_ptr ptr, int64_t size, int64_t uniqueID) {
-  auto site = std::make_shared<__mpk_untrusted::AllocSite>(ptr, size, uniqueID);
+void allocHook(rust_ptr ptr, int64_t size, int64_t localID, const char *bbName, const char* funcName) {
+  __mpk_untrusted::AllocSite site(ptr, size, localID, bbName, funcName);
   auto handler = __mpk_untrusted::AllocSiteHandler::getOrInit();
   handler->insertAllocSite(ptr, site);
-  REPORT("INFO : AllocSiteHook for address: %p ID: %d.\n", ptr, uniqueID);
+  REPORT("INFO : AllocSiteHook for address: %p ID: %d.\n", ptr, localID);
 
 #ifdef MPK_STATS
   if (AllocSiteCount != 0)
@@ -42,10 +42,19 @@ void allocHook(rust_ptr ptr, int64_t size, int64_t uniqueID) {
 /// where the oldAllocSite is added as part of the set of associated allocations
 /// for the new mapping.
 void reallocHook(rust_ptr newPtr, int64_t newSize, rust_ptr oldPtr,
-                 int64_t oldSize, int64_t uniqueID) {
+                 int64_t oldSize, int64_t localID, const char *bbName, const char *funcName) {
   // Get the AllocSiteHandler and the old AllocSite for the associated oldPtr.
   auto handler = __mpk_untrusted::AllocSiteHandler::getOrInit();
   auto assocSite = handler->getAllocSite(oldPtr);
+
+  if (!assocSite.isValid()) {
+    // Returned ErrorAlloc, which should not be part of the realloc chain.
+    __mpk_untrusted::AllocSite site(newPtr, newSize, localID, bbName, funcName);
+    handler->insertAllocSite(newPtr, site);
+    REPORT("ERROR<AllocSite> : Realloc Site: %p : %d could not find the associated previous allocation: %d\n",
+            newPtr, site.id(), assocSite.id());
+    return;
+  }
 
   // Get the previously associated set from the site being re-allocated and
   // add the previous site to the associated set.
@@ -58,10 +67,10 @@ void reallocHook(rust_ptr newPtr, int64_t newSize, rust_ptr oldPtr,
   // Create new Allocation Site for given pointer, adding the previous
   // Allocation Site and its associated set to the new AllocSite's associated
   // set.
-  __mpk_untrusted::AllocSite site(newPtr, newSize, uniqueID, bbN, fnN, 0, 1, assocSet);
+  __mpk_untrusted::AllocSite site(newPtr, newSize, localID, bbName, funcName, 0, 1, assocSet);
   handler->insertAllocSite(newPtr, site);
   REPORT("INFO : ReallocSiteHook for oldptr: %p, newptr: %p, ID: %d.\n",
-         oldPtr, newPtr, uniqueID);
+         oldPtr, newPtr, localID);
 
 #ifdef MPK_STATS
   if (AllocSiteCount != 0)
@@ -69,10 +78,10 @@ void reallocHook(rust_ptr newPtr, int64_t newSize, rust_ptr oldPtr,
 #endif
 }
 
-void deallocHook(rust_ptr ptr, int64_t size, int64_t uniqueID) {
+void deallocHook(rust_ptr ptr, int64_t size, int64_t localID) {
   auto handler = __mpk_untrusted::AllocSiteHandler::getOrInit();
   handler->removeAllocSite(ptr);
-  REPORT("INFO : DeallocSiteHook for address: %p ID: %d.\n", ptr, uniqueID);
+  REPORT("INFO : DeallocSiteHook for address: %p ID: %d.\n", ptr, localID);
 
 #ifdef MPK_STATS
   if (AllocSiteCount != 0)

--- a/compiler-rt/lib/mpk_untrusted/alloc_site_handler.cpp
+++ b/compiler-rt/lib/mpk_untrusted/alloc_site_handler.cpp
@@ -7,7 +7,6 @@ bool is_safe_address(void *addr) { return false; }
 namespace __mpk_untrusted {
 #define DEFAULT_PKEY 0
 
-
 AllocSiteHandler *AllocSiteHandle = nullptr;
 
 std::once_flag AllocHandlerInitFlag;

--- a/compiler-rt/lib/mpk_untrusted/alloc_site_handler.h
+++ b/compiler-rt/lib/mpk_untrusted/alloc_site_handler.h
@@ -15,7 +15,7 @@
 
 typedef int8_t *rust_ptr;
 extern "C" {
-  extern bool is_safe_address(void* addr);
+  extern bool __attribute__((weak)) is_safe_address(void* addr);
 }
 
 namespace __mpk_untrusted {
@@ -28,10 +28,10 @@ namespace __mpk_untrusted {
  * @param size Size of given allocation.
  * @param localID A function local identifier to track faulting allocations in the
  * runtime back to locations in source code.
- * @param pkey The Pkey that the given AllocationSite faulted on attempted
- * access.
  * @param bbName Name associated with containing basic block from source.
  * @param funcName Name associated with containing function from source.
+ * @param pkey The Pkey that the given AllocationSite faulted on attempted
+ * access.
  * @param isRealloc Simple marker for determining if an allocation site is
  * an alloc call or a realloc call. Mostly used for confirming results of 
  * traces.
@@ -60,9 +60,9 @@ private:
   rust_ptr ptr;
   int64_t size;
   int64_t localID;
-  uint32_t pkey;
   std::string bbName;
   std::string funcName;
+  uint32_t pkey;
   uint32_t isRealloc;
   alloc_set_type associatedSet;
   AllocSite() : ptr(nullptr), size(-1), localID(-1), 

--- a/compiler-rt/lib/mpk_untrusted/alloc_site_handler.h
+++ b/compiler-rt/lib/mpk_untrusted/alloc_site_handler.h
@@ -146,13 +146,6 @@ public:
     } else {
       return funcName < ac.getFuncName();
     }
-  };
-
-  // Additionally required for AllocSite to be hashable.
-  bool operator==(const AllocSite &ac) const {
-    return funcName.compare(ac.getFuncName()) == 0
-           && bbName.compare(ac.getBBName()) == 0
-           && localID == ac.id();
   }
 
   // Additionally required for AllocSite to be hashable.

--- a/compiler-rt/lib/mpk_untrusted/alloc_site_handler.h
+++ b/compiler-rt/lib/mpk_untrusted/alloc_site_handler.h
@@ -11,7 +11,9 @@
 #include <mutex>
 #include <set>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
+#include <functional>
 
 typedef int8_t *rust_ptr;
 extern "C" {
@@ -111,7 +113,7 @@ public:
 
   uint32_t getPkey() { return pkey; }
 
-  std::string getBBName() { return bbName; }
+  std::string getBBName() const { return bbName; }
 
   std::string getFuncName() const { return funcName; }
 
@@ -121,16 +123,43 @@ public:
   // previous allocation sites for a given reallocated pointer.
   alloc_set_type& getAssociatedSet() { return associatedSet; }
 
+  // This struct is required for hashing the AllocSite properly in the unordered_set.
+  // Some Additional shuffling is used in the hashing of multiple values to ensure 
+  // that if the Function name and BasicBlock name happen to match, they do not 
+  // cancel each other out.
+  struct Hasher {
+    std::size_t operator()(const AllocSite& AC) const {
+      return ((std::hash<std::string>()(AC.getFuncName())
+              ^ (std::hash<std::string>()(AC.getBBName()) << 1)) >> 1)
+              ^ (std::hash<int64_t>()(AC.id()) << 1);
+    }
+  };
+
+  // Used for internal associated set.
   bool operator<(const AllocSite &ac) const {
     if (funcName.compare(ac.getFuncName()) == 0) {
-      if (localID == ac.id()) {
-        ptr < ac.getPtr();
-      } else {
+      if (bbName.compare(ac.getBBName()) == 0) {
         return localID < ac.id();
+      } else {
+        return bbName < ac.getBBName();
       }
     } else {
       return funcName < ac.getFuncName();
     }
+  };
+
+  // Additionally required for AllocSite to be hashable.
+  bool operator==(const AllocSite &ac) const {
+    return funcName.compare(ac.getFuncName()) == 0
+           && bbName.compare(ac.getBBName()) == 0
+           && localID == ac.id();
+  }
+
+  // Additionally required for AllocSite to be hashable.
+  bool operator==(const AllocSite &ac) const {
+    return funcName.compare(ac.getFuncName()) == 0
+           && bbName.compare(ac.getBBName()) == 0
+           && localID == ac.id();
   }
 };
 
@@ -175,7 +204,7 @@ private:
   // allocation_map mutex
   std::mutex alloc_map_mx;
   // Set of faulting AllocationSites
-  std::set<AllocSite> fault_set;
+  std::unordered_set<AllocSite, AllocSite::Hasher> fault_set;
   // Fault set mutex
   std::mutex fault_set_mx;
   // Mapping of thread-id to saved pkey information
@@ -311,7 +340,7 @@ public:
     return ret_val;
   }
 
-  std::set<AllocSite> &faultingAllocs() {
+  std::unordered_set<AllocSite, AllocSite::Hasher> &faultingAllocs() {
     const std::lock_guard<std::mutex> fault_set_guard(fault_set_mx);
     return fault_set;
   }

--- a/compiler-rt/lib/mpk_untrusted/alloc_site_handler.h
+++ b/compiler-rt/lib/mpk_untrusted/alloc_site_handler.h
@@ -43,8 +43,8 @@ namespace __mpk_untrusted {
  * track the pointer of the allocation, the size of the allocation, and a
  * <localID, basicBlockName, funcName> tuple for tracking the call to alloc back
  * to its position in the source code. This information is intended to be used
- * in the compilation process for changing Allocation Site found to be unsafe to
- * unsafe alloc calls.
+ * in the compilation process for changing Allocation Sites that should be untrusted
+ * to untrusted alloc calls.
  *
  * @note A note on thread safety: The only parameter that is changed at any
  * point after object creation is the PKey that the object faults on, thus this

--- a/compiler-rt/lib/mpk_untrusted/mpk_common.h
+++ b/compiler-rt/lib/mpk_untrusted/mpk_common.h
@@ -7,11 +7,14 @@
 #include <cstdio>
 #include <cstring>
 
-#define PAGE_MPK 0
-#define SINGLE_STEP 1
+// MPK Runtime mode can be set with either of the two following flags,
+// PAGE_MPK and SINGLE_STEP_MPK. If neither are defined, default is 
+// set to SINGLE_STEP_MPK.
+#if !defined(PAGE_MPK) && !defined(SINGLE_STEP_MPK)
+  #define SINGLE_STEP_MPK
+#endif
 
 // Flag for controlling optional Stats tracking
-#define MPK_STATS
 #ifdef MPK_STATS
 #include <atomic>
 
@@ -23,7 +26,6 @@ extern std::atomic<uint64_t> deallocHookCalls;
 extern std::atomic<uint64_t> AllocSiteCount;
 #endif
 
-// #define MPK_ENABLE_LOGGING
 #ifdef MPK_ENABLE_LOGGING
 #define REPORT(...) __sanitizer::Report(__VA_ARGS__)
 #else
@@ -31,5 +33,13 @@ extern std::atomic<uint64_t> AllocSiteCount;
   do {                                                                         \
   } while (0)
 #endif
+
+// SINGLE_REPORT functions as the macro above but is intended
+// for one off testing when something specific is being debugged
+// rather than a general logging macro. Unlike the `REPORT` macro
+// this one is not controlled by an `#ifdef` and thus should always
+// be removed after usage (or replaced with REPORT if logging is
+// desired long term).
+#define SINGLE_REPORT(...) __sanitizer::Report(__VA_ARGS__)
 
 #endif // MPK_COMMON_H

--- a/compiler-rt/lib/mpk_untrusted/mpk_common.h
+++ b/compiler-rt/lib/mpk_untrusted/mpk_common.h
@@ -7,13 +7,6 @@
 #include <cstdio>
 #include <cstring>
 
-// MPK Runtime mode can be set with either of the two following flags,
-// PAGE_MPK and SINGLE_STEP_MPK. If neither are defined, default is 
-// set to SINGLE_STEP_MPK.
-#if !defined(PAGE_MPK) && !defined(SINGLE_STEP_MPK)
-  #define SINGLE_STEP_MPK
-#endif
-
 // Flag for controlling optional Stats tracking
 #ifdef MPK_STATS
 #include <atomic>

--- a/compiler-rt/lib/mpk_untrusted/mpk_fault_handler.cpp
+++ b/compiler-rt/lib/mpk_untrusted/mpk_fault_handler.cpp
@@ -24,12 +24,11 @@ void disableMPK(siginfo_t *si, void *arg);
 // MPK faults would be required).
 void segMPKHandle(int sig, siginfo_t *si, void *arg) {
   if (si->si_code != SEGV_PKUERR) {
-    REPORT("INFO : SegFault other than SEGV_PKUERR, handling with "
-           "default handler.\n");
+    REPORT("INFO : SegFault other than SEGV_PKUERR.\n");
     // SignalHandler was invoked from an error other than MPK violation.
     // Perform default action instead and return.
     if (!prevAction) {
-      REPORT("ERROR : prevAction is null, no previous handler to fall back to.\n");
+      REPORT("INFO : There is no previously saved action for SIGSEGV, handling with default signal handler.\n");
       signal(sig, SIG_DFL);
       raise(sig);
       return;
@@ -97,10 +96,10 @@ void enableThreadMPK(void *arg, PendingPKeyInfo pkey_info) {
 }
 
 void disableMPK(siginfo_t *si, void *arg) {
-#if PAGE_MPK
+#ifdef PAGE_MPK
   disablePageMPK(si, arg);
 #else
-#if SINGLE_STEP
+#ifdef SINGLE_STEP_MPK
   disableThreadMPK(arg, si->si_pkey);
 
   // Set trap flag on next instruction

--- a/compiler-rt/lib/mpk_untrusted/mpk_fault_handler.cpp
+++ b/compiler-rt/lib/mpk_untrusted/mpk_fault_handler.cpp
@@ -43,8 +43,13 @@ void segMPKHandle(int sig, siginfo_t *si, void *arg) {
   // Get Alloc Site information from the handler.
   auto handler = AllocSiteHandler::getOrInit();
   handler->addFaultAlloc((rust_ptr)ptr, pkey);
+  auto fault_site = handler->getAllocSite((rust_ptr)ptr);
+  if (!fault_site.isValid()) {
+    SINGLE_REPORT("ERROR : Error AllocSite on address: %p; is_safe_addr: %s\n",
+                        ptr, is_safe_address(ptr) ? "true" : "false");
+  }
   REPORT("INFO : Got Allocation Site (%d) for address: %p with pkey: %d.\n",
-         handler->getAllocSite((rust_ptr)ptr)->id(), ptr, pkey);
+         handler->getAllocSite((rust_ptr)ptr).id(), ptr, pkey);
   disableMPK(si, arg);
 }
 
@@ -52,7 +57,7 @@ void segMPKHandle(int sig, siginfo_t *si, void *arg) {
 void disablePageMPK(siginfo_t *si, void *arg) {
   void *page_addr = (void *)((uintptr_t)si->si_addr & ~(PAGE_SIZE - 1));
 
-  REPORT("Disabling MPK protection for page(%p).\n", page_addr);
+  REPORT("INFO : Disabling MPK protection for page(%p).\n", page_addr);
 
   pkey_mprotect(page_addr, PAGE_SIZE, PROT_READ | PROT_WRITE, 0);
 }
@@ -98,7 +103,7 @@ void disableMPK(siginfo_t *si, void *arg) {
 // In the single step approach, we trap after stepping a single instruction and
 // then re-enable the pkey in the current thread.
 void stepMPKHandle(int sig, siginfo_t *si, void *arg) {
-  REPORT("Reached signal handler after single instruction step.\n");
+  REPORT("INFO : Reached signal handler after single instruction step.\n");
   auto handler = AllocSiteHandler::getOrInit();
   auto pid_key_info = handler->getAndRemove(getpid());
   if (pid_key_info)

--- a/compiler-rt/lib/mpk_untrusted/mpk_fault_handler.cpp
+++ b/compiler-rt/lib/mpk_untrusted/mpk_fault_handler.cpp
@@ -28,7 +28,7 @@ void segMPKHandle(int sig, siginfo_t *si, void *arg) {
     // SignalHandler was invoked from an error other than MPK violation.
     // Perform default action instead and return.
     if (!prevAction) {
-      REPORT("INFO : There is no previously saved action for SIGSEGV, handling with default signal handler.\n");
+      REPORT("INFO : No existing SIGSEGV handler, falling back to default signal handler.\n");
       signal(sig, SIG_DFL);
       raise(sig);
       return;
@@ -96,18 +96,15 @@ void enableThreadMPK(void *arg, PendingPKeyInfo pkey_info) {
 }
 
 void disableMPK(siginfo_t *si, void *arg) {
-#ifdef PAGE_MPK
-  disablePageMPK(si, arg);
-#else
-#ifdef SINGLE_STEP_MPK
+#ifndef PAGE_MPK
+  // If PAGE_MPK not defined, default to Single Step
   disableThreadMPK(arg, si->si_pkey);
 
   // Set trap flag on next instruction
   ucontext_t *uctxt = (ucontext_t *)arg;
   uctxt->uc_mcontext.gregs[REG_EFL] |= TF;
 #else
-  // TODO : emulateMPK();
-#endif
+  disablePageMPK(si, arg);
 #endif
 }
 

--- a/compiler-rt/lib/mpk_untrusted/mpk_fault_handler.cpp
+++ b/compiler-rt/lib/mpk_untrusted/mpk_fault_handler.cpp
@@ -28,8 +28,20 @@ void segMPKHandle(int sig, siginfo_t *si, void *arg) {
            "default handler.\n");
     // SignalHandler was invoked from an error other than MPK violation.
     // Perform default action instead and return.
-    signal(sig, SIG_DFL);
-    raise(sig);
+    if (!prevAction) {
+      REPORT("ERROR : prevAction is null, no previous handler to fall back to.\n");
+      signal(sig, SIG_DFL);
+      raise(sig);
+      return;
+    }
+    if (prevAction->sa_flags & SA_SIGINFO) {
+      prevAction->sa_sigaction(sig, si, arg);
+    } else if (prevAction->sa_handler == SIG_DFL ||
+               prevAction->sa_handler == SIG_IGN) {
+      sigaction(sig, prevAction, nullptr);
+    } else {
+      prevAction->sa_handler(sig);
+    }
     return;
   }
   REPORT("INFO : Handling SEGV_PKUERR.\n");

--- a/compiler-rt/lib/mpk_untrusted/mpk_fault_handler.cpp
+++ b/compiler-rt/lib/mpk_untrusted/mpk_fault_handler.cpp
@@ -28,7 +28,8 @@ void segMPKHandle(int sig, siginfo_t *si, void *arg) {
     // SignalHandler was invoked from an error other than MPK violation.
     // Perform default action instead and return.
     if (!prevAction) {
-      REPORT("INFO : No existing SIGSEGV handler, falling back to default signal handler.\n");
+      REPORT("INFO : No existing SIGSEGV handler, falling back to default "
+             "signal handler.\n");
       signal(sig, SIG_DFL);
       raise(sig);
       return;
@@ -57,7 +58,7 @@ void segMPKHandle(int sig, siginfo_t *si, void *arg) {
   auto fault_site = handler->getAllocSite((rust_ptr)ptr);
   if (!fault_site.isValid()) {
     SINGLE_REPORT("ERROR : Error AllocSite on address: %p; is_safe_addr: %s\n",
-                        ptr, is_safe_address(ptr) ? "true" : "false");
+                  ptr, is_safe_address(ptr) ? "true" : "false");
   }
   REPORT("INFO : Got Allocation Site (%d) for address: %p with pkey: %d.\n",
          handler->getAllocSite((rust_ptr)ptr).id(), ptr, pkey);

--- a/compiler-rt/lib/mpk_untrusted/mpk_formatter.cpp
+++ b/compiler-rt/lib/mpk_untrusted/mpk_formatter.cpp
@@ -142,7 +142,7 @@ void flush_allocs() {
     return;
   }
 
-  REPORT("INFO : Beginning faulting alloc flush.\n");
+  REPORT("INFO : Serializing faulting allocations to disk.\n");
 
   // Simple method that requires either handling multiple files or a script for
   // combining them later.
@@ -150,7 +150,7 @@ void flush_allocs() {
     REPORT("ERROR : Unable to successfully write unique files for "
            "given program run.\n");
 
-  REPORT("INFO : Finished flushing faulted allocs\n");
+  REPORT("INFO : Serialization complete.\n");
 }
 
 } // namespace __mpk_untrusted

--- a/compiler-rt/lib/mpk_untrusted/mpk_formatter.cpp
+++ b/compiler-rt/lib/mpk_untrusted/mpk_formatter.cpp
@@ -72,7 +72,7 @@ bool is_directory(std::string directory) {
 // Function for handwriting the JSON output we want (to remove dependency on
 // llvm/Support).
 void writeJSON(std::ofstream &OS,
-               std::set<AllocSite> &faultSet) {
+               std::unordered_set<AllocSite, AllocSite::Hasher> &faultSet) {
   if (faultSet.size() <= 0)
     return;
 
@@ -90,7 +90,7 @@ void writeJSON(std::ofstream &OS,
 
 // Writes output of the faultSet to a uniquely generated output file to ensure
 // we do not overwrite previously discovered faulting values.
-bool writeUniqueFile(std::set<AllocSite> &faultSet) {
+bool writeUniqueFile(std::unordered_set<AllocSite, AllocSite::Hasher> &faultSet) {
   // Currently all results are stored by default in the folder TestResults.
   // Ensure this folder exists, or create one if it does not.
   std::string TestDirectory = "TestResults";

--- a/compiler-rt/lib/mpk_untrusted/mpk_formatter.cpp
+++ b/compiler-rt/lib/mpk_untrusted/mpk_formatter.cpp
@@ -71,8 +71,7 @@ bool is_directory(std::string directory) {
 
 // Function for handwriting the JSON output we want (to remove dependency on
 // llvm/Support).
-void writeJSON(std::ofstream &OS,
-               std::unordered_set<AllocSite, AllocSite::Hasher> &faultSet) {
+void writeJSON(std::ofstream &OS, std::unordered_set<AllocSite> &faultSet) {
   if (faultSet.size() <= 0)
     return;
 
@@ -81,16 +80,17 @@ void writeJSON(std::ofstream &OS,
   for (auto fault : faultSet) {
     --items_remaining;
     OS << "{ \"id\": " << fault.id() << ", \"pkey\": " << fault.getPkey()
-       << ", \"bbName\": \"" << fault.getBBName() << "\", \"funcName\": \"" 
-       << fault.getFuncName() << "\"" << ", \"isRealloc\": " << fault.isReAlloc()
-       << " }" << (items_remaining ? "," : "") << "\n";
+       << ", \"bbName\": \"" << fault.getBBName() << "\", \"funcName\": \""
+       << fault.getFuncName() << "\""
+       << ", \"isRealloc\": " << (fault.isReAlloc() ? "true" : "false") << " }"
+       << (items_remaining ? "," : "") << "\n";
   }
   OS << "]\n";
 }
 
 // Writes output of the faultSet to a uniquely generated output file to ensure
 // we do not overwrite previously discovered faulting values.
-bool writeUniqueFile(std::unordered_set<AllocSite, AllocSite::Hasher> &faultSet) {
+bool writeUniqueFile(std::unordered_set<AllocSite> &faultSet) {
   // Currently all results are stored by default in the folder TestResults.
   // Ensure this folder exists, or create one if it does not.
   std::string TestDirectory = "TestResults";

--- a/compiler-rt/lib/mpk_untrusted/mpk_formatter.cpp
+++ b/compiler-rt/lib/mpk_untrusted/mpk_formatter.cpp
@@ -81,6 +81,8 @@ void writeJSON(std::ofstream &OS,
   for (auto fault : faultSet) {
     --items_remaining;
     OS << "{ \"id\": " << fault.id() << ", \"pkey\": " << fault.getPkey()
+       << ", \"bbName\": \"" << fault.getBBName() << "\", \"funcName\": \"" 
+       << fault.getFuncName() << "\"" << ", \"isRealloc\": " << fault.isReAlloc()
        << " }" << (items_remaining ? "," : "") << "\n";
   }
   OS << "]\n";

--- a/compiler-rt/lib/mpk_untrusted/mpk_untrusted.cpp
+++ b/compiler-rt/lib/mpk_untrusted/mpk_untrusted.cpp
@@ -17,7 +17,7 @@ std::atomic<uint64_t> AllocSiteCount(0);
 
 extern "C" {
 void mpk_SEGV_fault_handler(void *oldact) {
-  REPORT("INFO : Replacing SEGV fault handler with ours.\n");
+  REPORT("INFO : Replacing SIGSEGV fault handler with __mpk_untrusted::segMPKHandle.\n");
   if (!SEGVAction) {
     static struct sigaction sa;
     memset(&sa, 0, sizeof(struct sigaction));
@@ -66,7 +66,7 @@ void mpk_untrusted_constructor() {
     SEGVAction = &sa;
   prevAction = &sa_old;
 
-#if SINGLE_STEP
+#ifdef SINGLE_STEP_MPK
   // If we are single stepping, we add an additional signal handler.
   static struct sigaction sa_trap;
 

--- a/compiler-rt/lib/mpk_untrusted/mpk_untrusted.cpp
+++ b/compiler-rt/lib/mpk_untrusted/mpk_untrusted.cpp
@@ -18,7 +18,8 @@ std::atomic<uint64_t> AllocSiteCount(0);
 
 extern "C" {
 void mpk_SEGV_fault_handler(void *oldact) {
-  REPORT("INFO : Replacing SIGSEGV fault handler with __mpk_untrusted::segMPKHandle.\n");
+  REPORT("INFO : Replacing SIGSEGV fault handler with "
+         "__mpk_untrusted::segMPKHandle.\n");
   if (!SEGVAction) {
     static struct sigaction sa;
     memset(&sa, 0, sizeof(struct sigaction));

--- a/compiler-rt/lib/mpk_untrusted/mpk_untrusted.cpp
+++ b/compiler-rt/lib/mpk_untrusted/mpk_untrusted.cpp
@@ -2,6 +2,7 @@
 #include "mpk_common.h"
 #include "mpk_fault_handler.h"
 #include "sanitizer_common/sanitizer_common.h"
+#include <cstdint>
 
 struct sigaction *prevAction = nullptr;
 struct sigaction *SEGVAction = nullptr;
@@ -66,7 +67,8 @@ void mpk_untrusted_constructor() {
     SEGVAction = &sa;
   prevAction = &sa_old;
 
-#ifdef SINGLE_STEP_MPK
+// If PAGE_MPK is not defined, default to Single Step
+#ifndef PAGE_MPK
   // If we are single stepping, we add an additional signal handler.
   static struct sigaction sa_trap;
 

--- a/compiler-rt/lib/mpk_untrusted/mpk_untrusted.h
+++ b/compiler-rt/lib/mpk_untrusted/mpk_untrusted.h
@@ -1,7 +1,10 @@
 #ifndef MPKUNTRUSTED_H
 #define MPKUNTRUSTED_H
 
+extern struct sigaction *prevAction;
+
 extern "C" {
+__attribute__((visibility("default"))) void mpk_SEGV_fault_handler(void *oldAct = nullptr);
 __attribute__((visibility("default"))) void mpk_untrusted_constructor();
 }
 

--- a/llvm/lib/Transforms/IPO/DynUntrustedAllocPost.cpp
+++ b/llvm/lib/Transforms/IPO/DynUntrustedAllocPost.cpp
@@ -43,7 +43,6 @@
 
 #include <fstream>
 #include <map>
-#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -269,7 +268,7 @@ public:
 
   std::map<std::string, std::map<uint64_t, FaultingSite>> getFaultingAllocMap() {
     std::map<std::string, std::map<uint64_t, FaultingSite>> fault_map;
-    // If no path provided, return empty set.
+    // If no path provided, return empty map.
     if (mpk_profile_path.empty())
       return fault_map;
 
@@ -295,7 +294,7 @@ public:
       }
     }
 
-    LLVM_DEBUG(errs() << "Returning successful fault_set.\n");
+    LLVM_DEBUG(errs() << "Returning successful fault_map.\n");
     return fault_map;
   }
 
@@ -406,7 +405,7 @@ public:
             auto allocFunc = CS.getArgument(0);
             if (auto *allocInst = dyn_cast<CallBase>(allocFunc)) {
 
-              // Check to see if ID is in fault set for patching
+              // Check to see if ID is in fault map for patching
               auto &func_fault_map = func_fault_iter->second;
               auto map_iter = func_fault_map.find(id->getZExtValue());
               if (map_iter == func_fault_map.end()) {

--- a/llvm/lib/Transforms/IPO/DynUntrustedAllocPost.cpp
+++ b/llvm/lib/Transforms/IPO/DynUntrustedAllocPost.cpp
@@ -49,8 +49,8 @@
 #include <set>
 
 #define DEBUG_TYPE "dyn-untrusted"
+// Used for printing compile time statistics for DynUntrustedAllocPost pass.
 #define MPK_STATS
-#define MPK_PATCH_INST_DEBUG
 
 using namespace llvm;
 
@@ -64,6 +64,10 @@ static cl::opt<bool>
     MPKTestRemoveHooks("mpk-test-remove-hooks", cl::init(false), cl::Hidden,
                        cl::desc("Remove hook instructions. This is mainly"
                                 "for test purpose."));
+
+static cl::opt<bool>
+    MPKVerbosePatching("mpk-verbose-patching", cl::init(false), cl::Hidden,
+                       cl::desc("Print out patched instructions on instrumentation pass."));
 
 namespace {
 #ifdef MPK_STATS
@@ -184,7 +188,7 @@ public:
   // fromJSON(const json::Value&, T&) -> bool
   // which passes the JSON object as its first argument and a reference
   // to the data structure you are deserializing as the second argument.
-  // The T/F return is in reference to the stability of the deserialized
+  // The boolean return is in reference to the stability of the deserialized
   // object and should be handled by the caller.
   bool fromJSON(const llvm::json::Value &Alloc, FaultingSite &F) {
     llvm::json::ObjectMapper O(Alloc);
@@ -378,12 +382,17 @@ public:
           // Set LocalID for hook function
           auto id = LocalIDG.getConstID(M);
           CS.setArgument(index, id);
-          IRBuilder<> IRB(&*callInst);
-          // Set the Basic Block name, which is at index + 1
-          CS.setArgument(index + 1, IRB.CreateGlobalStringPtr(bbName));
-          // Set the Function name, which is at index + 2
-          CS.setArgument(index + 2, IRB.CreateGlobalStringPtr(funcName));
- 
+          if (!remove_hooks) {
+            // We only want to create these global strings if they are going to be used in 
+            // final program execution. When removing the hooks, skip creating (and assigning)
+            // the Global String identifiers.
+            IRBuilder<> IRB(&*callInst);
+            // Set the Basic Block name, which is at index + 1
+            CS.setArgument(index + 1, IRB.CreateGlobalStringPtr(bbName));
+            // Set the Function name, which is at index + 2
+            CS.setArgument(index + 2, IRB.CreateGlobalStringPtr(funcName));
+          }
+
           // If provided a valid path, modify given instruction
           if (!mpk_profile_path.empty()) {
             // Check to see if this function contains any faults
@@ -430,9 +439,8 @@ public:
 
     auto replacementFunctionName = repl_iter->second;
 
-#ifdef MPK_PATCH_INST_DEBUG
-    errs() << "Patching instruction: " << *inst << "\n";
-#endif
+    if (MPKVerbosePatching)
+      errs() << "Patching instruction: " << *inst << "\n";
 
     Function *repl_func = M.getFunction(replacementFunctionName);
     if (!repl_func) {
@@ -449,6 +457,29 @@ public:
 #endif
   }
 
+  // Working under the assumption that all missed cases of Hook calls is 
+  // due to the blocks containing them no longer being reachable, we remove
+  // those instructions from their respective blocks.
+  void removeFunctionUsers(Function *F) {
+    for (auto user : F->users()) {
+      if (auto *inst = dyn_cast<Instruction>(user)) {
+        salvageDebugInfo(*inst);
+        inst->eraseFromParent();
+#ifdef MPK_STATS
+        total_hooks++;
+        auto trackedHook = hookCountMap.find(F->getName().str());
+        if (trackedHook != hookCountMap.end())
+          trackedHook->second++;
+#endif
+      } else {
+        errs() << "User not an instruction: " << *user << "\n";
+        assert(false && "Function user not an instruction!");
+      }
+    }
+    F->setLinkage(GlobalValue::LinkageTypes::InternalLinkage);
+    F->eraseFromParent();
+  }
+
   void removeHooks(Module &M) {
     for (auto inst : hookList) {
       salvageDebugInfo(*inst);
@@ -456,54 +487,16 @@ public:
     }
 
     auto allocHook = M.getFunction("allocHook");
+    if (allocHook)
+      removeFunctionUsers(allocHook);
+
     auto reallocHook = M.getFunction("reallocHook");
+    if (reallocHook)
+      removeFunctionUsers(reallocHook);
+    
     auto deallocHook = M.getFunction("deallocHook");
-
-    // Working under the assumption that all missed cases of Hook calls is 
-    // due to the blocks containing them no longer being reachable, we remove
-    // those instructions from their respective blocks.
-    for (auto user : allocHook->users()) {
-      if (auto *inst = dyn_cast<Instruction>(user)) {
-        // TODO : Check to ensure instruction or block is unreachable
-        salvageDebugInfo(*inst);
-        inst->eraseFromParent();
-        total_hooks++;
-        hookCountMap.find("allocHook")->second++;
-      } else {
-        errs() << "User not an instruction: " << *user << "\n";
-        assert(false && "AllocHook user not an instruction!");
-      }
-    }
-    allocHook->setLinkage(GlobalValue::LinkageTypes::InternalLinkage);
-    allocHook->eraseFromParent();
-
-    for (auto user : reallocHook->users()) {
-      if (auto *inst = dyn_cast<Instruction>(user)) {
-       salvageDebugInfo(*inst);
-       inst->eraseFromParent();
-       total_hooks++;
-       hookCountMap.find("reallocHook")->second++;
-      } else {
-        errs() << "User not an instruction: " << *user << "\n";
-        assert(false && "ReAllocHook user not an instruction!");
-      }
-    }
-    reallocHook->setLinkage(GlobalValue::LinkageTypes::InternalLinkage);
-    reallocHook->eraseFromParent();
-
-    for (auto user : deallocHook->users()) {
-      if (auto *inst = dyn_cast<Instruction>(user)) {
-        salvageDebugInfo(*inst);
-        inst->eraseFromParent();
-        total_hooks++;
-        hookCountMap.find("deallocHook")->second++;
-      } else {
-        errs() << "User not an instruction: " << *user << "\n";
-        assert(false && "DeAllocHook user not an instruction!");
-      }
-    }
-    deallocHook->setLinkage(GlobalValue::LinkageTypes::InternalLinkage);
-    deallocHook->eraseFromParent();
+    if (deallocHook)
+      removeFunctionUsers(deallocHook);
   }
 
   /// Iterate all Functions of Module M, remove NoInline attribute from

--- a/llvm/lib/Transforms/IPO/DynUntrustedAllocPre.cpp
+++ b/llvm/lib/Transforms/IPO/DynUntrustedAllocPre.cpp
@@ -41,6 +41,7 @@
 #include <string>
 
 #define DEBUG_TYPE "dyn-untrusted"
+// Used for printing compile time statistics for DynUntrustedAllocPre pass.
 #define MPK_STATS
 
 using namespace llvm;

--- a/llvm/lib/Transforms/IPO/DynUntrustedAllocPre.cpp
+++ b/llvm/lib/Transforms/IPO/DynUntrustedAllocPre.cpp
@@ -77,7 +77,8 @@ public:
     // Adds function hooks with dummy LocalIDs immediately after calls
     // to __rust_alloc* functions. Additionally, we must remove the
     // NoInline attribute from RustAlloc functions.
-    GlobalNullStr = llvm::ConstantPointerNull::get(Type::getInt8PtrTy(M.getContext()));
+    GlobalNullStr =
+        llvm::ConstantPointerNull::get(Type::getInt8PtrTy(M.getContext()));
 
     AttrBuilder attrBldr;
     attrBldr.addAttribute(Attribute::NoUnwind);
@@ -88,33 +89,36 @@ public:
 
     // Make function hook to add to all functions we wish to track
     Constant *allocHookFunc = M.getOrInsertFunction(
-        "allocHook", fnAttrs, Type::getVoidTy(M.getContext()),    // void allocHook(
-        Type::getInt8PtrTy(M.getContext()),                       // (int8_t *)rust_ptr ptr,
-        IntegerType::get(M.getContext(), 64),                     // int64_t size,
-        IntegerType::getInt64Ty(M.getContext()),                  // int64_t localID,
-        Type::getInt8PtrTy(M.getContext()),                       // const char *bbName,
-        Type::getInt8PtrTy(M.getContext()));                      // const char *funcName)
+        "allocHook", fnAttrs,
+        Type::getVoidTy(M.getContext()),         // void allocHook(
+        Type::getInt8PtrTy(M.getContext()),      // (int8_t *)rust_ptr ptr,
+        IntegerType::get(M.getContext(), 64),    // int64_t size,
+        IntegerType::getInt64Ty(M.getContext()), // int64_t localID,
+        Type::getInt8PtrTy(M.getContext()),      // const char *bbName,
+        Type::getInt8PtrTy(M.getContext()));     // const char *funcName)
     allocHook = cast<Function>(allocHookFunc);
     // set its linkage
     allocHook->setLinkage(GlobalValue::LinkageTypes::ExternalLinkage);
 
     Constant *reallocHookFunc = M.getOrInsertFunction(
-        "reallocHook", fnAttrs, Type::getVoidTy(M.getContext()),  // void reallocHook(
-        Type::getInt8PtrTy(M.getContext()),                       // rust_ptr newPtr,
-        IntegerType::get(M.getContext(), 64),                     // int64_t newSize,
-        Type::getInt8PtrTy(M.getContext()),                       // rust_ptr oldPtr,
-        IntegerType::get(M.getContext(), 64),                     // int64_t oldSize,
-        IntegerType::getInt64Ty(M.getContext()),                  // int64_t localID,
-        Type::getInt8PtrTy(M.getContext()),                       // const char *bbName,
-        Type::getInt8PtrTy(M.getContext()));                      // const char *funcName)
+        "reallocHook", fnAttrs,
+        Type::getVoidTy(M.getContext()),         // void reallocHook(
+        Type::getInt8PtrTy(M.getContext()),      // rust_ptr newPtr,
+        IntegerType::get(M.getContext(), 64),    // int64_t newSize,
+        Type::getInt8PtrTy(M.getContext()),      // rust_ptr oldPtr,
+        IntegerType::get(M.getContext(), 64),    // int64_t oldSize,
+        IntegerType::getInt64Ty(M.getContext()), // int64_t localID,
+        Type::getInt8PtrTy(M.getContext()),      // const char *bbName,
+        Type::getInt8PtrTy(M.getContext()));     // const char *funcName)
     reallocHook = cast<Function>(reallocHookFunc);
     reallocHook->setLinkage(GlobalValue::LinkageTypes::ExternalLinkage);
 
     Constant *deallocHookFunc = M.getOrInsertFunction(
-        "deallocHook", fnAttrs, Type::getVoidTy(M.getContext()),  // void deallocHook(
-        Type::getInt8PtrTy(M.getContext()),                       // rust_ptr ptr,
-        IntegerType::get(M.getContext(), 64),                     // int64_t size,
-        IntegerType::getInt64Ty(M.getContext()));                 // int64_t localID)
+        "deallocHook", fnAttrs,
+        Type::getVoidTy(M.getContext()),          // void deallocHook(
+        Type::getInt8PtrTy(M.getContext()),       // rust_ptr ptr,
+        IntegerType::get(M.getContext(), 64),     // int64_t size,
+        IntegerType::getInt64Ty(M.getContext())); // int64_t localID)
     deallocHook = cast<Function>(deallocHookFunc);
     deallocHook->setLinkage(GlobalValue::LinkageTypes::ExternalLinkage);
 
@@ -141,10 +145,9 @@ public:
 #ifdef MPK_STATS
       alloc_hook_counter++;
 #endif
-      return CallInst::Create(
-          (Function *)allocHook,
-          {CS->getInstruction(), CS->getArgument(0), getDummyID(M), 
-           GlobalNullStr, GlobalNullStr});
+      return CallInst::Create((Function *)allocHook,
+                              {CS->getInstruction(), CS->getArgument(0),
+                               getDummyID(M), GlobalNullStr, GlobalNullStr});
     } else if (F == M.getFunction("__rust_realloc")) {
 #ifdef MPK_STATS
       realloc_hook_counter++;
@@ -268,9 +271,9 @@ public:
         llvm::GlobalValue::LinkageTypes::ExternalLinkage);
     if (rust_untrusted_alloc_zeroed) {
       rust_untrusted_alloc_zeroed->setLinkage(
-        llvm::GlobalValue::LinkageTypes::ExternalLinkage);
+          llvm::GlobalValue::LinkageTypes::ExternalLinkage);
     }
-   
+
     for (Function &F : M) {
       if (F.hasFnAttribute(Attribute::RustAllocator)) {
         // Dont inline any functions that may be altered or hooked in the

--- a/llvm/lib/Transforms/Instrumentation/MpkCallGates.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MpkCallGates.cpp
@@ -38,7 +38,7 @@ bool MpkCallGatesLegacyPass::runOnModule(Module &M) {
     // and only if they may be called from outside of rust code
     // i.e., externally available or are address taken functions
     if (!(F.hasAddressTaken() || F.hasLinkOnceLinkage() ||
-        F.hasAvailableExternallyLinkage() || !F.hasLocalLinkage()))
+          F.hasAvailableExternallyLinkage() || !F.hasLocalLinkage()))
       continue;
 
     // ignore our APIs


### PR DESCRIPTION
Runtime Changes:
- Changed the AllocSiteHandler from a singleton shared_ptr to a singleton pointer that is not freed
  to avoid runtime issues. The previous shared_ptr approach would deallocate the AllocSiteHandler
  before program execution completed, giving inconsistent results when hooks were being hit in later
  parts of execution. This change prevents that.
- Changed all AllocSite objects from shared_ptr references to objects that are copied when moved.
  This is in conjunction with the issue faced above.
- Added additional information to AllocSite to support new tracking scheme (the basic block and
  function name).
- Added function call to runtime for replacing segfault handler in programs that overwrite (or
  actively use SIGSEGV) to ensure that our handler is called first and all subsequent handles for
  that signal are preserved.

Transform Changes:
- For increased stability in mapping tracing UniqueIDs to instrumentation (or final build) UniqueIDs
  we switched from a whole program UniqueID count to a perfection count, together with the function
  and basic block name, similar to PGO in LLVM.
- Added addtional handling for function hook cleanup phase for instrumented build runs to ensure
  that all hooks are removed from the program even if they are not found using the RPOT sweep.
- Removed deallocHook from the UniqueID count as they do not use the UniqueID they are given, and
  ignoring them increases stability of mapping between trace and instrument builds.
- Fixed some logic in CallGate pass and removed AlwaysInline traits.