### PR TITLE
Fixed some logic for MPK CallGates:

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/MpkCallGates.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MpkCallGates.cpp
@@ -37,13 +37,13 @@ bool MpkCallGatesLegacyPass::runOnModule(Module &M) {
 
     // and only if they may be called from outside of rust code
     // i.e., externally available or are address taken functions
-    if (!F.hasAddressTaken() || !F.hasLinkOnceLinkage() ||
-        !F.hasAvailableExternallyLinkage() || !F.hasLocalLinkage())
+    if (!(F.hasAddressTaken() || F.hasLinkOnceLinkage() ||
+        F.hasAvailableExternallyLinkage() || !F.hasLocalLinkage()))
       continue;
 
     // ignore our APIs
     if (F.getName() == "__untrusted_gate_enter" ||
-        F.getName() == "__untrusted_gate_enter") {
+        F.getName() == "__untrusted_gate_exit") {
       F.removeFnAttr("rust_api");
       continue;
     }
@@ -60,14 +60,12 @@ bool MpkCallGatesLegacyPass::runOnModule(Module &M) {
         M.getOrInsertFunction("__untrusted_gate_enter", IRB.getVoidTy());
     auto *Fn = cast<Function>(Callee); // die on sig mismatch
     Fn->addFnAttr(Attribute::NoUnwind);
-     Fn->addFnAttr(Attribute::AlwaysInline);
   }
   /* scope */ {
     auto Callee =
         M.getOrInsertFunction("__untrusted_gate_exit", IRB.getVoidTy());
     auto *Fn = cast<Function>(Callee); // die on sig mismatch
     Fn->addFnAttr(Attribute::NoUnwind);
-     Fn->addFnAttr(Attribute::AlwaysInline);
   }
 
   auto PushFn =
@@ -100,7 +98,6 @@ bool MpkCallGatesLegacyPass::runOnModule(Module &M) {
     CI->setTailCall();
     CI->setCallingConv(F->getCallingConv());
     CI->setAttributes(F->getAttributes());
-    CI->setIsNoInline();
     if (F->getReturnType()->isVoidTy()) {
       Builder.CreateRetVoid();
     } else {


### PR DESCRIPTION
- Fixed the if statement for excluding functions not containing some form of external linkage or reference
- Fixed typo for removing `rust_api` attribute
- Removed `AlwaysInline` attribute that would clash with previously set `NeverInline` attributes